### PR TITLE
Subtract correct ounces from current volume

### DIFF
--- a/ui/src/app/components/dashboard/dashboard.component.ts
+++ b/ui/src/app/components/dashboard/dashboard.component.ts
@@ -37,7 +37,7 @@ export class DashboardComponent implements OnInit {
       console.log(keg.beer[0].beername +" poured " + ounces + "ounces");
 
       //subtract a pint
-      keg.currentvolume--;
+      keg.currentvolume = keg.currentvolume - ounces;
       console.log("New Volume: " + keg.currentvolume);
 
       this.kegService.editKeg(keg)


### PR DESCRIPTION
When the relevant "Pour" buttons are clicked, subtract the corresponding ounces from the current volume instead of just 1.